### PR TITLE
Update API base URLs to use customer subdomain format

### DIFF
--- a/api-reference.mdx
+++ b/api-reference.mdx
@@ -7,8 +7,8 @@ description: "Complete reference for the Truust REST API v2.0"
 
 The Truust API is organized around REST. All requests must be made over HTTPS to:
 
-- **Production:** `https://api.truust.io/2.0`
-- **Sandbox:** `https://api-sandbox.truust.io/2.0`
+- **Production:** `https://<your subdomain>.truust.io/2.0`
+- **Sandbox:** `https://<your subdomain>-sandbox.truust.io/2.0`
 
 ## Authentication
 

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -21,10 +21,18 @@ info:
     name: Proprietary
 
 servers:
-  - url: https://api.truust.io/2.0
+  - url: https://{subdomain}.truust.io/2.0
     description: Production
-  - url: https://api-sandbox.truust.io/2.0
+    variables:
+      subdomain:
+        default: your-subdomain
+        description: Your account subdomain
+  - url: https://{subdomain}-sandbox.truust.io/2.0
     description: Sandbox
+    variables:
+      subdomain:
+        default: your-subdomain
+        description: Your account subdomain
 
 security:
   - bearerAuth: []

--- a/developers.md
+++ b/developers.md
@@ -55,8 +55,8 @@ The environment specifies where requests via the API should be directed – sand
 
 There are both production and sandbox environments for the API. The URL endpoints will be:
 
-- https://api-sandbox.truust.io/ - Testing environment
-- https://api.truust.io/ - Live production environment
+- `https://<your subdomain>-sandbox.truust.io/2.0` - Testing environment
+- `https://<your subdomain>.truust.io/2.0` - Live production environment
 
 ## Webhooks
 


### PR DESCRIPTION
Replace hardcoded api.truust.io URLs with <your subdomain>.truust.io pattern across api-reference.mdx, developers.md, and openapi.yaml servers section.